### PR TITLE
Feature/add-lambda-name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [22.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
     
     - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdkless",
-      "version": "0.1.0-beta.1",
+      "version": "0.1.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdkless",
-      "version": "0.1.0-beta.0",
+      "version": "0.1.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdkless",
-      "version": "0.1.0-beta.2",
+      "version": "0.1.0-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.5",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lambda-builder.ts
+++ b/src/lambda-builder.ts
@@ -11,7 +11,7 @@ import * as cdk from 'aws-cdk-lib';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
 import { Construct } from 'constructs';
-import { Names, Stack } from 'aws-cdk-lib';
+import { Stack } from 'aws-cdk-lib';
 import { ApiBuilder } from './api-builder';
 
 export interface LambdaBuilderProps {
@@ -101,14 +101,8 @@ export class LambdaBuilder {
     
     // Extract the last segment of the handler path
     this.handlerPath = props.handler;
-    const segments = this.handlerPath.split('/');
-    const lastSegment = segments[segments.length - 1];
-    
-    // Generate resource name (kebab-case)
-    this.resourceName = lastSegment;
-    
-    // Generate ID
-    this.id = Names.uniqueId(this.scope);
+    this.resourceName = this.handlerPath.split('/').pop() || '';
+    this.id = this.resourceName;
     
     // Initialize Lambda registry for this stack if it doesn't exist
     const stackId = this.stack.stackId;
@@ -191,6 +185,15 @@ export class LambdaBuilder {
       },
       environment: this.environmentVars,
     });
+  }
+
+  /**
+   * Sets the name of the Lambda function
+   * @param name Name of the Lambda function
+   */
+  public name(name: string): LambdaBuilder {
+    this.resourceName = name;
+    return this;
   }
 
   /**


### PR DESCRIPTION
- Update package version to 0.1.0-beta.5
- Update GitHub workflow to use Node.js 22.x
- Refactor LambdaBuilder to simplify resource name and ID generation
- Add new `name()` method to LambdaBuilder for custom function naming