### PR TITLE
Refactor API and Lambda builders with improved route configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.5",
+  "version": "0.1.0-beta.6",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/api-builder.ts
+++ b/src/api-builder.ts
@@ -1,7 +1,7 @@
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
-import * as apigatewayv2_integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
-import { Construct } from 'constructs';
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as apigatewayv2_integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { Construct } from "constructs";
 
 export interface ApiBuilderProps {
   scope: Construct;
@@ -14,6 +14,14 @@ export interface ApiBuilderProps {
   disableExecuteApiEndpoint?: boolean;
 }
 
+export interface Route {
+  path: string;
+  resourceName: string;
+  lambda: lambda.Function;
+  method: string;
+  options?: RouteOptions;
+}
+
 export interface RouteOptions {
   authorizer?: apigatewayv2.IHttpRouteAuthorizer;
   authorizationScopes?: string[];
@@ -22,100 +30,95 @@ export interface RouteOptions {
 
 export class ApiBuilder {
   private api: apigatewayv2.HttpApi;
-  private scope: Construct;
   private stageName: string;
   private routes: Map<string, string> = new Map();
 
   constructor(props: ApiBuilderProps) {
-    this.scope = props.scope;
-    this.stageName = props.stageName || 'default';
-    
-    // Configuración de la API
+    this.stageName = props.stageName || "default";
+
     let apiConfig: apigatewayv2.HttpApiProps = {
       apiName: props.apiName || `${props.id}-api`,
-      description: props.description || 'API created with ApiBuilder',
-      disableExecuteApiEndpoint: props.disableExecuteApiEndpoint
+      description: props.description || "API created with ApiBuilder",
+      disableExecuteApiEndpoint: props.disableExecuteApiEndpoint,
     };
-    
-    // Añadir CORS solo si useDefaultCors no es false explícitamente
+
     if (props.useDefaultCors !== false) {
-      // Crear una nueva configuración que incluya CORS
       apiConfig = {
         ...apiConfig,
         corsPreflight: {
-          allowOrigins: ['*'],
+          allowOrigins: ["*"],
           allowMethods: [apigatewayv2.CorsHttpMethod.ANY],
-          allowHeaders: ['Content-Type', 'Authorization', 'X-Api-Key']
-        }
+          allowHeaders: ["Content-Type", "Authorization", "X-Api-Key"],
+        },
       };
     }
-    
-    // Crear la API con las propiedades configuradas
+
     this.api = new apigatewayv2.HttpApi(props.scope, props.id, apiConfig);
   }
 
   /**
    * Adds a route to the API
    * @param path Path to add
+   * @param resourceName Name of the resource
    * @param lambda Lambda function that will handle the route
    * @param method HTTP method (GET, POST, PUT, DELETE)
    * @param options Additional options for the route
    */
-  public addRoute(
-    path: string, 
-    lambda: lambda.Function, 
-    method: string,
-    options?: RouteOptions
-  ): ApiBuilder {
-    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-    
+  public addRoute({
+    path,
+    resourceName,
+    lambda,
+    method,
+    options,
+  }: Route): ApiBuilder {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
     let httpMethod: apigatewayv2.HttpMethod;
     switch (method.toUpperCase()) {
-      case 'GET':
+      case "GET":
         httpMethod = apigatewayv2.HttpMethod.GET;
         break;
-      case 'POST':
+      case "POST":
         httpMethod = apigatewayv2.HttpMethod.POST;
         break;
-      case 'PUT':
+      case "PUT":
         httpMethod = apigatewayv2.HttpMethod.PUT;
         break;
-      case 'DELETE':
+      case "DELETE":
         httpMethod = apigatewayv2.HttpMethod.DELETE;
         break;
-      case 'PATCH':
+      case "PATCH":
         httpMethod = apigatewayv2.HttpMethod.PATCH;
         break;
-      case 'OPTIONS':
+      case "OPTIONS":
         httpMethod = apigatewayv2.HttpMethod.OPTIONS;
         break;
-      case 'HEAD':
+      case "HEAD":
         httpMethod = apigatewayv2.HttpMethod.HEAD;
         break;
       default:
         throw new Error(`Unsupported HTTP method: ${method}`);
     }
-    
-    // Generar un ID estable para la integración que no contenga tokens
-    const integrationId = `${path.replace(/\//g, '-')}-${method.toLowerCase()}-integration`;
-    
+
+    const integrationId = `${method}-${resourceName}-integration`;
+
     const integration = new apigatewayv2_integrations.HttpLambdaIntegration(
       integrationId,
       lambda
     );
-    
+
     const routeConfig: apigatewayv2.AddRoutesOptions = {
       path: normalizedPath,
       methods: [httpMethod],
       integration: integration,
       ...(options?.authorizer && { authorizer: options.authorizer }),
     };
-    
+
     const routes = this.api.addRoutes(routeConfig);
     const route = routes[0];
-    
+
     this.routes.set(normalizedPath, route.routeId);
-    
+
     return this;
   }
 
@@ -142,8 +145,8 @@ export class ApiBuilder {
    * @returns The full URL for the specified endpoint
    */
   public getEndpoint(path: string, stage?: string): string {
-    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
     const stagePath = stage || this.stageName;
     return `${this.api.apiEndpoint}/${stagePath}${normalizedPath}`;
   }
-} 
+}

--- a/src/lambda-builder.ts
+++ b/src/lambda-builder.ts
@@ -1,22 +1,22 @@
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
-import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
-import * as sns from 'aws-cdk-lib/aws-sns';
-import * as sqs from 'aws-cdk-lib/aws-sqs';
-import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as s3n from 'aws-cdk-lib/aws-s3-notifications';
-import * as cdk from 'aws-cdk-lib';
-import * as logs from 'aws-cdk-lib/aws-logs';
-import * as lambdaEventSources from 'aws-cdk-lib/aws-lambda-event-sources';
-import { Construct } from 'constructs';
-import { Stack } from 'aws-cdk-lib';
-import { ApiBuilder } from './api-builder';
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as s3n from "aws-cdk-lib/aws-s3-notifications";
+import * as cdk from "aws-cdk-lib";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as lambdaEventSources from "aws-cdk-lib/aws-lambda-event-sources";
+import { Construct } from "constructs";
+import { Stack } from "aws-cdk-lib";
+import { ApiBuilder } from "./api-builder";
 
 export interface LambdaBuilderProps {
-  scope: Construct;      // Scope is still required for CDK
-  handler: string;       // Only required parameter - path to handler (without extension)
+  scope: Construct; // Scope is still required for CDK
+  handler: string; // Only required parameter - path to handler (without extension)
 }
 
 // Interfaces for trigger configuration options
@@ -42,13 +42,13 @@ export interface S3Options {
 
 // Interface for IAM policy configuration options
 export interface PolicyOptions {
-  includeSubResources?: boolean;  // If true, also adds `${arn}/*` as a resource
-  effect?: iam.Effect;            // Effect.ALLOW by default
+  includeSubResources?: boolean; // If true, also adds `${arn}/*` as a resource
+  effect?: iam.Effect; // Effect.ALLOW by default
 }
 
 // Interface to store trigger information
 interface TriggerInfo {
-  type: 'sns' | 'sqs' | 's3' | 'api';
+  type: "sns" | "sqs" | "s3" | "api";
   resourceArn?: string;
   resourceName?: string;
   method?: string;
@@ -76,7 +76,7 @@ export class LambdaBuilder {
   private id: string;
   private resourceName: string;
   private environmentVars: { [key: string]: string } = {
-    STAGE: process.env.STAGE || ''
+    STAGE: process.env.STAGE || "",
   };
   private stack: Stack;
   private triggers: TriggerInfo[] = [];
@@ -84,7 +84,7 @@ export class LambdaBuilder {
   private isBuilt = false;
   private isAutoBuilding = false;
   private authorizer?: apigatewayv2.IHttpRouteAuthorizer;
-  
+
   // New configuration properties with default values
   private runtimeValue: lambda.Runtime = lambda.Runtime.NODEJS_22_X;
   private memorySize: number = 256;
@@ -95,15 +95,15 @@ export class LambdaBuilder {
   constructor(props: LambdaBuilderProps) {
     this.scope = props.scope;
     this.stack = Stack.of(this.scope);
-    
+
     // Get stage from environment variables
-    this.stage = process.env.STAGE || '';
-    
+    this.stage = process.env.STAGE || "";
+
     // Extract the last segment of the handler path
     this.handlerPath = props.handler;
-    this.resourceName = this.handlerPath.split('/').pop() || '';
+    this.resourceName = this.handlerPath.split("/").pop() || "";
     this.id = this.resourceName;
-    
+
     // Initialize Lambda registry for this stack if it doesn't exist
     const stackId = this.stack.stackId;
     if (!lambdaRegistry.has(stackId)) {
@@ -115,47 +115,47 @@ export class LambdaBuilder {
       get: (target: LambdaBuilder, prop: string | symbol, receiver: any) => {
         // First get the original method or property
         const original = Reflect.get(target, prop, receiver);
-        
+
         // If it's not a function, simply return it
-        if (typeof original !== 'function') {
+        if (typeof original !== "function") {
           return original;
         }
-        
+
         // If it is a function, return a wrapped version
-        return function(...args: any[]) {
+        return function (...args: any[]) {
           // If we're trying to access build(), simply execute it
-          if (prop === 'build') {
+          if (prop === "build") {
             return original.apply(target, args);
           }
-          
+
           // If we're trying to access getLambda() and it hasn't been built, build first
-          if (prop === 'getLambda' && !target.isBuilt) {
+          if (prop === "getLambda" && !target.isBuilt) {
             target.build();
             return original.apply(target, args);
           }
-          
+
           // For any other class method
           // Set a flag to prevent recursion during building
           if (!target.isAutoBuilding) {
             target.isAutoBuilding = true;
-            
+
             // Execute the original method
             const result = original.apply(target, args);
-            
+
             // If the method returns the current object (this) for chaining
             // and we've finished with all configurations, automatically build
             if (result === target && !target.isBuilt) {
               // Lambda will be automatically built when the chain ends
               setTimeout(() => target.build(), 0);
             }
-            
+
             target.isAutoBuilding = false;
             return result;
           } else {
             return original.apply(target, args);
           }
         };
-      }
+      },
     });
   }
 
@@ -165,7 +165,7 @@ export class LambdaBuilder {
   private createNodejsFunction(): lambda.Function {
     // Asegurarnos de que tenemos un handlerPath definido
     if (!this.handlerPath) {
-      throw new Error('Handler path is not defined');
+      throw new Error("Handler path is not defined");
     }
 
     return new NodejsFunction(this.scope, `${this.id}-function`, {
@@ -175,11 +175,9 @@ export class LambdaBuilder {
       timeout: this.timeoutDuration,
       logRetention: this.logRetentionDays,
       entry: `${this.handlerPath}.ts`,
-      handler: 'handler',
+      handler: "handler",
       bundling: {
-        externalModules: [
-          'aws-sdk',
-        ],
+        externalModules: ["aws-sdk"],
         minify: true,
         sourceMap: true,
       },
@@ -239,64 +237,64 @@ export class LambdaBuilder {
   public environment(variables: { [key: string]: string }): LambdaBuilder {
     this.environmentVars = {
       ...this.environmentVars,
-      ...variables
+      ...variables,
     };
     return this;
   }
 
   public get(path: string): LambdaBuilder {
-    this.method = 'GET';
+    this.method = "GET";
     this.path = path;
-    
+
     // Register the API trigger
     this.triggers.push({
-      type: 'api',
-      method: 'GET',
+      type: "api",
+      method: "GET",
       path: path,
     });
-    
+
     return this;
   }
 
   public post(path: string): LambdaBuilder {
-    this.method = 'POST';
+    this.method = "POST";
     this.path = path;
-    
+
     // Register the API trigger
     this.triggers.push({
-      type: 'api',
-      method: 'POST',
+      type: "api",
+      method: "POST",
       path: path,
     });
-    
+
     return this;
   }
 
   public put(path: string): LambdaBuilder {
-    this.method = 'PUT';
+    this.method = "PUT";
     this.path = path;
-    
+
     // Register the API trigger
     this.triggers.push({
-      type: 'api',
-      method: 'PUT',
+      type: "api",
+      method: "PUT",
       path: path,
     });
-    
+
     return this;
   }
 
   public delete(path: string): LambdaBuilder {
-    this.method = 'DELETE';
+    this.method = "DELETE";
     this.path = path;
-    
+
     // Register the API trigger
     this.triggers.push({
-      type: 'api',
-      method: 'DELETE',
+      type: "api",
+      method: "DELETE",
       path: path,
     });
-    
+
     return this;
   }
 
@@ -304,7 +302,9 @@ export class LambdaBuilder {
    * Sets an authorizer for the API Gateway route
    * @param authorizer An instance of IHttpRouteAuthorizer (HttpJwtAuthorizer, HttpLambdaAuthorizer, etc.)
    */
-  public addAuthorizer(authorizer: apigatewayv2.IHttpRouteAuthorizer): LambdaBuilder {
+  public addAuthorizer(
+    authorizer: apigatewayv2.IHttpRouteAuthorizer
+  ): LambdaBuilder {
     this.authorizer = authorizer;
     return this;
   }
@@ -315,22 +315,26 @@ export class LambdaBuilder {
    * @param actions List of IAM actions to allow
    * @param options Additional policy configuration options
    */
-  public addPolicy(arn: string, actions: string[], options?: PolicyOptions): LambdaBuilder {
+  public addPolicy(
+    arn: string,
+    actions: string[],
+    options?: PolicyOptions
+  ): LambdaBuilder {
     const policyStatement = new iam.PolicyStatement({
-      effect: options?.effect || iam.Effect.ALLOW
+      effect: options?.effect || iam.Effect.ALLOW,
     });
-    
+
     const resources = [arn];
-    
+
     if (options?.includeSubResources) {
       resources.push(`${arn}/*`);
     }
-    
+
     policyStatement.addResources(...resources);
     policyStatement.addActions(...actions);
-    
+
     this.lambda.addToRolePolicy(policyStatement);
-    
+
     return this;
   }
 
@@ -340,28 +344,32 @@ export class LambdaBuilder {
    * @param options Additional options for the SNS subscription
    */
   public addSnsTrigger(topicArn: string, options?: SnsOptions): LambdaBuilder {
-    const topic = sns.Topic.fromTopicArn(this.scope, `${this.id}-imported-topic-${this.stage}`, topicArn);
-    
+    const topic = sns.Topic.fromTopicArn(
+      this.scope,
+      `${this.id}-imported-topic-${this.stage}`,
+      topicArn
+    );
+
     const snsEventSource = new lambdaEventSources.SnsEventSource(topic, {
       filterPolicy: options?.filterPolicy,
       deadLetterQueue: options?.deadLetterQueue,
     });
-    
+
     this.lambda.addEventSource(snsEventSource);
-    
+
     this.lambda.addPermission(`${this.id}-sns-permission-${this.stage}`, {
-      principal: new iam.ServicePrincipal('sns.amazonaws.com'),
+      principal: new iam.ServicePrincipal("sns.amazonaws.com"),
       sourceArn: topic.topicArn,
     });
-    
-    const topicName = topicArn.split(':').pop() || 'unknown-topic';
-    
+
+    const topicName = topicArn.split(":").pop() || "unknown-topic";
+
     this.triggers.push({
-      type: 'sns',
+      type: "sns",
       resourceArn: topicArn,
-      resourceName: topicName
+      resourceName: topicName,
     });
-    
+
     return this;
   }
 
@@ -371,8 +379,12 @@ export class LambdaBuilder {
    * @param options Additional options for the SQS configuration
    */
   public addSqsTrigger(queueArn: string, options?: SqsOptions): LambdaBuilder {
-    const queue = sqs.Queue.fromQueueArn(this.scope, `${this.id}-imported-queue-${this.stage}`, queueArn);
-    
+    const queue = sqs.Queue.fromQueueArn(
+      this.scope,
+      `${this.id}-imported-queue-${this.stage}`,
+      queueArn
+    );
+
     const sqsEventSource = new lambdaEventSources.SqsEventSource(queue, {
       batchSize: options?.batchSize || 10,
       maxBatchingWindow: options?.maxBatchingWindow,
@@ -380,19 +392,19 @@ export class LambdaBuilder {
       reportBatchItemFailures: options?.reportBatchItemFailures,
       maxConcurrency: options?.maxConcurrency,
     });
-    
+
     this.lambda.addEventSource(sqsEventSource);
-    
+
     queue.grantConsumeMessages(this.lambda);
-    
-    const queueName = queueArn.split(':').pop() || 'unknown-queue';
-    
+
+    const queueName = queueArn.split(":").pop() || "unknown-queue";
+
     this.triggers.push({
-      type: 'sqs',
+      type: "sqs",
       resourceArn: queueArn,
       resourceName: queueName,
     });
-    
+
     return this;
   }
 
@@ -402,29 +414,33 @@ export class LambdaBuilder {
    * @param options Additional options for the S3 configuration
    */
   public addS3Trigger(bucketArn: string, options?: S3Options): LambdaBuilder {
-    const bucket = s3.Bucket.fromBucketArn(this.scope, `${this.id}-imported-bucket-${this.stage}`, bucketArn);
-    
+    const bucket = s3.Bucket.fromBucketArn(
+      this.scope,
+      `${this.id}-imported-bucket-${this.stage}`,
+      bucketArn
+    );
+
     const events = options?.events || [s3.EventType.OBJECT_CREATED];
-    
+
     const filters: s3.NotificationKeyFilter[] = [];
-    
+
     if (options?.prefix) {
       filters.push({ prefix: options.prefix });
     }
     if (options?.suffix) {
       filters.push({ suffix: options.suffix });
     }
-    
+
     if (options?.filters && options.filters.length > 0) {
       filters.push(...options.filters);
     }
-    
+
     bucket.addEventNotification(
-      events[0], 
+      events[0],
       new s3n.LambdaDestination(this.lambda),
       ...filters
     );
-    
+
     if (events.length > 1) {
       for (let i = 1; i < events.length; i++) {
         bucket.addEventNotification(
@@ -434,25 +450,34 @@ export class LambdaBuilder {
         );
       }
     }
-    
-    this.lambda.addToRolePolicy(new iam.PolicyStatement({
-      actions: ['s3:GetObject', 's3:ListBucket'],
-      resources: [bucket.bucketArn, `${bucket.bucketArn}/*`],
-    }));
-    
-    const bucketName = bucketArn.split(':').pop() || bucketArn.split(':::').pop() || 'unknown-bucket';
-    
+
+    this.lambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ["s3:GetObject", "s3:ListBucket"],
+        resources: [bucket.bucketArn, `${bucket.bucketArn}/*`],
+      })
+    );
+
+    const bucketName =
+      bucketArn.split(":").pop() ||
+      bucketArn.split(":::").pop() ||
+      "unknown-bucket";
+
     this.triggers.push({
-      type: 's3',
+      type: "s3",
       resourceArn: bucketArn,
       resourceName: bucketName,
     });
-    
+
     return this;
   }
 
   public addTablePermissions(tableArn: string): LambdaBuilder {
-    const table = dynamodb.Table.fromTableArn(this.scope, `${this.id}-imported-table-${this.stage}`, tableArn);
+    const table = dynamodb.Table.fromTableArn(
+      this.scope,
+      `${this.id}-imported-table-${this.stage}`,
+      tableArn
+    );
     table.grantReadWriteData(this.lambda);
     return this;
   }
@@ -463,22 +488,22 @@ export class LambdaBuilder {
    */
   private getOrCreateSharedApi(): ApiBuilder {
     const stackId = this.stack.stackId;
-    
+
     if (sharedApis.has(stackId)) {
       return sharedApis.get(stackId)!;
     }
-    
+
     const apiBuilder = new ApiBuilder({
       scope: this.scope,
-      id: `${this.stack.stackName}-SharedApi-${this.stage}`,
+      id: `${this.stack.stackName}-api-${this.stage}`,
       apiName: `${this.stack.stackName}-api-${this.stage}`,
       description: `Shared API created automatically - ${this.stage}`,
       stageName: this.stage,
-      useDefaultCors: true
+      useDefaultCors: true,
     });
-    
+
     sharedApis.set(stackId, apiBuilder);
-    
+
     return apiBuilder;
   }
 
@@ -492,17 +517,23 @@ export class LambdaBuilder {
 
     if (this.method && this.path) {
       const sharedApi = this.getOrCreateSharedApi();
-      
+
       const routeOptions: any = {};
-      
+
       if (this.authorizer) {
         routeOptions.authorizer = this.authorizer;
       }
-      
-      sharedApi.addRoute(this.path, this.lambda, this.method, routeOptions);
-      
-      this.triggers = this.triggers.map(trigger => {
-        if (trigger.type === 'api') {
+
+      sharedApi.addRoute({
+        path: this.path,
+        resourceName: this.resourceName,
+        lambda: this.lambda,
+        method: this.method,
+        options: routeOptions,
+      });
+
+      this.triggers = this.triggers.map((trigger) => {
+        if (trigger.type === "api") {
           return {
             ...trigger,
             resourceArn: sharedApi.getApiUrl(),
@@ -517,11 +548,11 @@ export class LambdaBuilder {
     lambdaInfos.push({
       id: this.id,
       lambda: this.lambda,
-      triggers: [...this.triggers]
+      triggers: [...this.triggers],
     });
-    
+
     this.generateCfnOutputs();
-    
+
     this.isBuilt = true;
     return this.lambda;
   }
@@ -533,53 +564,64 @@ export class LambdaBuilder {
       const stackId = this.stack.stackId;
       const lambdaInfos = lambdaRegistry.get(stackId)!;
       const sharedApi = sharedApis.get(stackId);
-      
+
       if (!sharedApi) return;
-      
+
       // Solo crear CfnOutput si no estamos en un entorno de prueba
-      if (process.env.NODE_ENV !== 'test') {
+      if (process.env.NODE_ENV !== "test") {
         try {
           // Generate a CfnOutput for the API base URL
           new cdk.CfnOutput(this.scope, `ApiGatewayUrl-${this.stage}`, {
             value: sharedApi.getApiUrl(),
-            description: `Shared API Gateway base URL - ${this.stage}`
+            description: `Shared API Gateway base URL - ${this.stage}`,
           });
         } catch (error) {
-          console.warn('Unable to create CfnOutput for API URL:', error);
+          console.warn("Unable to create CfnOutput for API URL:", error);
         }
       }
-      
+
       // Generate CfnOutputs for each Lambda and its triggers
       lambdaInfos.forEach((lambdaInfo) => {
         const id = lambdaInfo.id;
         const triggers = lambdaInfo.triggers;
-        
+
         // Generate trigger details
-        const triggerDetails = triggers.map(trigger => {
-          switch (trigger.type) {
-            case 'api':
-              return `Lambda: [${id}] -> ${trigger.method} ${sharedApi.getEndpoint(trigger.path || '')}`;
-            case 'sns':
-              return `Lambda: [${id}] -> TRIGGERED by SNS [${trigger.resourceName}]`;
-            case 'sqs':
-              return `Lambda: [${id}] -> TRIGGERED by SQS [${trigger.resourceName}]`;
-            case 's3':
-              return `Lambda: [${id}] -> TRIGGERED by S3 [${trigger.resourceName}]`;
-            default:
-              return '';
-          }
-        }).filter(text => text !== '');
-        
+        const triggerDetails = triggers
+          .map((trigger) => {
+            switch (trigger.type) {
+              case "api":
+                return `Lambda: [${id}] -> ${
+                  trigger.method
+                } ${sharedApi.getEndpoint(trigger.path || "")}`;
+              case "sns":
+                return `Lambda: [${id}] -> TRIGGERED by SNS [${trigger.resourceName}]`;
+              case "sqs":
+                return `Lambda: [${id}] -> TRIGGERED by SQS [${trigger.resourceName}]`;
+              case "s3":
+                return `Lambda: [${id}] -> TRIGGERED by S3 [${trigger.resourceName}]`;
+              default:
+                return "";
+            }
+          })
+          .filter((text) => text !== "");
+
         if (triggerDetails.length > 0) {
           // Solo crear CfnOutput si no estamos en un entorno de prueba
-          if (process.env.NODE_ENV !== 'test') {
+          if (process.env.NODE_ENV !== "test") {
             try {
-              new cdk.CfnOutput(this.scope, `Lambda${id}Triggers-${this.stage}`, {
-                value: triggerDetails.join('\n'),
-                description: `Triggers for Lambda ${id} - ${this.stage}`
-              });
+              new cdk.CfnOutput(
+                this.scope,
+                `Lambda${id}Triggers-${this.stage}`,
+                {
+                  value: triggerDetails.join("\n"),
+                  description: `Triggers for Lambda ${id} - ${this.stage}`,
+                }
+              );
             } catch (error) {
-              console.warn(`Unable to create CfnOutput for Lambda ${id} triggers:`, error);
+              console.warn(
+                `Unable to create CfnOutput for Lambda ${id} triggers:`,
+                error
+              );
             }
           }
         }
@@ -590,9 +632,9 @@ export class LambdaBuilder {
   public getLambda(): lambda.Function {
     return this.lambda;
   }
-  
+
   public static getSharedApi(scope: Construct): ApiBuilder | undefined {
     const stack = Stack.of(scope);
     return sharedApis.get(stack.stackId);
   }
-} 
+}

--- a/tests/integration/CdkLess.integration.test.ts
+++ b/tests/integration/CdkLess.integration.test.ts
@@ -32,7 +32,6 @@ describe("CdkLess Integration Tests", () => {
     cdkless.lambda("tests/handlers/test-handler").build();
     
     const stack = cdkless.getStack();
-    cdkless.synth();
     const template = Template.fromStack(stack);
 
     template.hasResourceProperties("AWS::Lambda::Function", {
@@ -50,7 +49,6 @@ describe("CdkLess Integration Tests", () => {
       .build();
 
     const stack = cdkless.getStack();
-    cdkless.synth();
     const template = Template.fromStack(stack);
 
     template.resourceCountIs("AWS::Lambda::Function", 2);
@@ -80,7 +78,6 @@ describe("CdkLess Integration Tests", () => {
       .build();
     
     const stack = cdkless.getStack();
-    cdkless.synth();
     const template = Template.fromStack(stack);
     
     template.hasResourceProperties("AWS::Lambda::Function", {


### PR DESCRIPTION
- Update `ApiBuilder` to support more flexible route configuration
- Modify `addRoute` method to accept a single `Route` object
- Improve integration ID generation for Lambda routes
- Enhance type safety and configuration options
- Bump version to 0.1.0-beta.6