### PR TITLE
Feature/generate-lambda-name-by-default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdkless",
-      "version": "0.1.0-beta.9",
+      "version": "0.1.0-beta.10",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdkless",
-  "version": "0.1.0-beta.9",
+  "version": "0.1.0-beta.10",
   "description": "Ultra-simplified AWS CDK framework for building serverless microservices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lambda-builder.ts
+++ b/src/lambda-builder.ts
@@ -59,6 +59,7 @@ export class LambdaBuilder {
 
     // Extract the last segment of the handler path
     this.handlerPath = props.handler;
+    this.resourceName = this.handlerPath.split("/").pop() || "";
 
     // Initialize Lambda registry for this stack if it doesn't exist
     const stackId = this.stack.stackId;
@@ -121,10 +122,6 @@ export class LambdaBuilder {
   private createNodejsFunction(): lambda.Function {
     if (!this.handlerPath) {
       throw new Error("Handler path is not defined");
-    }
-
-    if (!this.resourceName) {
-      throw new Error("Resource name is not defined");
     }
 
     const logGroup = new logs.LogGroup(


### PR DESCRIPTION
- Add resourceName extraction from handler path
- Remove unnecessary resourceName validation check
- Simplify resource name generation logic