### PR TITLE
fix(lambda): fix applyDynamoStreamsTrigger method

### DIFF
--- a/src/interfaces/lambda/config-interfaces.ts
+++ b/src/interfaces/lambda/config-interfaces.ts
@@ -106,7 +106,7 @@ export interface SMKConfig {
  */
 export interface DynamoStreamsConfig {
   /** Name of the DynamoDB table */
-  tableName?: string;
+  tableName: string;
   /** ARN of the DynamoDB table */
   tableArn: string;
   /** Batch size for messages */

--- a/src/lambda-builder.ts
+++ b/src/lambda-builder.ts
@@ -699,12 +699,10 @@ export class LambdaBuilder {
 
   private applyDynamoStreamsTriggers(): void {
     for (const config of this.dynamoStreamsConfigs) {
-      const functionName = config.tableName ? Table.fromTableName : Table.fromTableArn;
-      const source = config.tableName ? config.tableName : config.tableArn;
-      const table: dynamodb.ITable = functionName(
+      const table: dynamodb.ITable = Table.fromTableArn(
         this.scope,
-        `${this.resourceName}-imported-table-${this.stage}-${this.dynamoStreamsConfigs.indexOf(config)}`,
-        source
+        config.tableName,
+        config.tableArn
       );
       const props: DynamoEventSourceProps = {
         batchSize: config.batchSize || 10,


### PR DESCRIPTION
This PR fixes the method for adding a DynamoDB Streams trigger:

- The use of tableName in the configuration parameters is mandatory to be used in the Name constructor of the Table.fromTableArn method that searches for the dynamo table that contains the stream.
- The name constructor creation string is removed due to an error in creating from the table ARN
- The config.tableArn is used as a source to find the ITable instance.