### PR TITLE
feat: Allow attaching an existing IAM role to Lambda functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,8 @@ This ensures that:
 
 Grant your Lambda functions access to AWS resources with a simple, chainable API:
 
+### Individual Permissions
+
 ```typescript
 // Add Grant DynamoDB table permissions
 app
@@ -639,6 +641,49 @@ app
   ])
   .addPolicy("arn:aws:sns:us-east-1:123456789012:mi-topic", ["SNS:Publish"]);
 ```
+
+### Adding an IAM Role (Optional)
+
+By default, CdkLess automatically creates a basic execution role for each Lambda function. This role grants permissions to write logs to Amazon CloudWatch. For many use cases, this is sufficient.
+
+However, if you need to grant your function more specific permissions, you can add a pre-existing IAM role using the `.addRole()` method. This overrides the default behavior and gives you full control over the function's permissions.
+
+You can add an existing IAM role in two ways:
+
+```typescript
+// 1. By ARN
+app
+  .lambda("src/handlers/admin/dashboard")
+  .get("/admin/dashboard")
+  .addRole({
+    roleArn: "arn:aws:iam::123456789012:role/my-existing-lambda-role"
+  });
+
+// 2. By providing an IRole construct
+const existingRole = iam.Role.fromRoleArn(
+  this,
+  "ImportedRole",
+  "arn:aws:iam::123456789012:role/another-existing-role"
+);
+
+app
+  .lambda("src/handlers/orders/process")
+  .post("/orders")
+  .addRole({
+    role: existingRole
+  });
+```
+
+**Key Points:**
+
+- **It's Optional**: You only need to use `.addRole()` if you want to use a specific, pre-existing role. If you don't call it, a default role will be created and managed for you.
+- **Role Must Exist**: The role you specify must already exist in your AWS account. CdkLess does not create new roles with this method.
+- **Permissions**: Ensure the role you provide has the necessary permissions. At a minimum, it needs the `AWSLambdaBasicExecutionRole` managed policy (or equivalent permissions) to allow the function to write logs.
+
+The `addRole` method accepts:
+
+- `role`: An existing IAM role construct (`iam.IRole`).
+- `roleArn`: The ARN of an existing IAM role to import and use.
 
 ## ✏️ Naming Lambda Functions
 

--- a/src/interfaces/lambda/index.ts
+++ b/src/interfaces/lambda/index.ts
@@ -2,3 +2,4 @@
 export * from './lambda-props';
 export * from './lambda-options';
 export * from './config-interfaces';
+export * from './lambda-vpc';

--- a/src/interfaces/lambda/lambda-props.ts
+++ b/src/interfaces/lambda/lambda-props.ts
@@ -22,4 +22,14 @@ export interface PolicyOptions {
   includeSubResources?: boolean;
   /** Effect.ALLOW by default */
   effect?: cdk.aws_iam.Effect;
+}
+
+/**
+ * Configuration for attaching an existing IAM role to a Lambda function
+ */
+export interface IamRoleConfig {
+  /** Existing IAM role to attach */
+  role?: cdk.aws_iam.IRole;
+  /** ARN of an existing IAM role to attach */
+  roleArn?: string;
 } 


### PR DESCRIPTION
Closes #39 

#### What's Changed?

This pull request introduces a new feature allowing developers to attach a pre-existing IAM role (`iam.Role`) to any Lambda function defined via Cdkless. Instead of Cdkless automatically creating a new role for each function, developers can now provide their own role during function definition.

#### Why is this change needed?

Currently, Cdkless creates a default IAM role for every Lambda function. While this is convenient for rapid development, it can be limiting in environments with stricter security and compliance requirements:

1.  **Principle of Least Privilege:** Enterprise environments often require IAM roles to be pre-approved with strictly defined, minimal permissions. This change enables the use of such fine-grained roles.
2.  **Policy Reusability:** It allows for the reuse of existing, centrally managed IAM roles and policies, which simplifies permissions management and ensures consistency across the infrastructure.
3.  **Simplified Permissions:** It makes it easier to assign roles that already have the necessary permissions to access other AWS resources (e.g., S3 buckets, DynamoDB tables) without needing to add inline policies manually within Cdkless.

This new capability provides greater flexibility and control over the security posture of the deployed Lambda functions.