### PR TITLE
docs: Update API documentation and enhance CORS configuration options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -97,6 +97,11 @@ const customApp = new CdkLess({
     - `environment`: ({ [key: string]: string }) Default environment variables
     - `logRetention`: (logs.RetentionDays) Default log retention period
     - These defaults can be overridden at the function level using the corresponding methods
+  - `settings.defaultApiOptions`: (Default: undefined) Default API Gateway configuration options:
+    - `cors`: Custom CORS configuration for API Gateway
+      - If not provided, default CORS is used (allow all origins)
+      - Set to `false` to disable CORS entirely
+      - Provide a `CorsPreflightOptions` object for custom CORS settings
 
 **Example with Default Lambda Options:**
 
@@ -153,6 +158,36 @@ const app = new CdkLess({
 // You can still add more tags later
 app.addStackTags({
   Critical: "true"
+});
+```
+
+**Example with Custom API Options (CORS):**
+
+```typescript
+import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
+
+const app = new CdkLess({
+  appName: "user-services",
+  settings: {
+    defaultApiOptions: {
+      cors: {
+        allowOrigins: ["https://example.com", "https://app.example.com"],
+        allowMethods: [apigatewayv2.CorsHttpMethod.GET, apigatewayv2.CorsHttpMethod.POST],
+        allowHeaders: ["Content-Type", "Authorization"],
+        maxAge: cdk.Duration.hours(1)
+      }
+    }
+  }
+});
+
+// To disable CORS entirely:
+const appNoCors = new CdkLess({
+  appName: "user-services",
+  settings: {
+    defaultApiOptions: {
+      cors: false
+    }
+  }
 });
 ```
 

--- a/src/api-builder.ts
+++ b/src/api-builder.ts
@@ -16,7 +16,12 @@ export class ApiBuilder {
       disableExecuteApiEndpoint: props.disableExecuteApiEndpoint,
     };
 
-    if (props.useDefaultCors !== false) {
+    if (props.corsConfig !== undefined && props.corsConfig !== false) {
+      apiConfig = {
+        ...apiConfig,
+        corsPreflight: props.corsConfig,
+      };
+    } else if (props.useDefaultCors !== false) {
       apiConfig = {
         ...apiConfig,
         corsPreflight: {

--- a/src/base-stack.ts
+++ b/src/base-stack.ts
@@ -203,4 +203,8 @@ export class CdkLess extends cdk.Stack implements IStack {
   public getStack() {
     return this;
   }
+
+  public getScope() {
+    return this.app;
+  }
 }

--- a/src/interfaces/api/api-defaults.ts
+++ b/src/interfaces/api/api-defaults.ts
@@ -1,0 +1,12 @@
+import { CorsPreflightOptions } from "aws-cdk-lib/aws-apigatewayv2";
+
+export interface DefaultApiOptions {
+  /**
+   * CORS configuration for the API Gateway.
+   * If not provided, default CORS will be used (allow all origins).
+   * Set to false to disable CORS entirely.
+   * 
+   * @default undefined (uses default CORS)
+   */
+  cors?: CorsPreflightOptions | false;
+}

--- a/src/interfaces/api/api-interfaces.ts
+++ b/src/interfaces/api/api-interfaces.ts
@@ -12,6 +12,7 @@ export interface ApiBuilderProps {
   description?: string;
   stageName?: string;
   useDefaultCors?: boolean;
+  corsConfig?: apigatewayv2.CorsPreflightOptions | false;
   binaryMediaTypes?: string[];
   disableExecuteApiEndpoint?: boolean;
 }

--- a/src/interfaces/api/index.ts
+++ b/src/interfaces/api/index.ts
@@ -1,2 +1,3 @@
 // Re-export all API Gateway-related interfaces
 export * from './api-interfaces'; 
+export * from './api-defaults';

--- a/src/interfaces/stack/index.ts
+++ b/src/interfaces/stack/index.ts
@@ -1,6 +1,7 @@
 import { BundlingOptions } from "aws-cdk-lib/aws-lambda-nodejs";
 import { DefaultLambdaOptions } from "../lambda/lambda-defaults";
 import { AwsResourceTags } from "../tags";
+import { DefaultApiOptions } from "../api/api-defaults";
 
 export interface IStackSettings {
   /**
@@ -39,6 +40,14 @@ export interface IStackSettings {
    * @default undefined (uses automatic ProjectName tag)
    */
   defaultTags?: AwsResourceTags;
+
+  /**
+   * Default API Gateway configuration options.
+   * This allows you to configure default settings for the shared API Gateway.
+   * 
+   * @default undefined
+   */
+  defaultApiOptions?: DefaultApiOptions;
 }
 
 /**

--- a/src/lambda-builder.ts
+++ b/src/lambda-builder.ts
@@ -747,13 +747,17 @@ export class LambdaBuilder {
     const apiName =
       this.stage.length > 0 ? `${appName}-api-${this.stage}` : `${appName}-api`;
 
+    const defaultSettings = CdkLess.getDefaultSettings();
+    const corsConfig = defaultSettings.defaultApiOptions?.cors;
+
     const apiBuilder = new ApiBuilder({
       scope: this.scope,
       id: apiName,
       apiName: apiName,
       description: `Shared API created automatically - ${this.stage}`,
       stageName: this.stage,
-      useDefaultCors: true,
+      useDefaultCors: corsConfig === undefined ? true : undefined,
+      corsConfig: corsConfig,
     });
 
     sharedApi = apiBuilder;


### PR DESCRIPTION
Added detailed documentation for the new `defaultApiOptions` in API.md, including custom CORS settings. Updated the ApiBuilder and LambdaBuilder to support custom CORS configurations and modified interfaces to include `corsConfig`. Introduced examples demonstrating the usage of custom CORS settings and the ability to disable CORS entirely.